### PR TITLE
refactor(presenter-manager): delete dependence on Android SDK

### DIFF
--- a/app/src/main/java/com/remind101/archexample/MainActivity.java
+++ b/app/src/main/java/com/remind101/archexample/MainActivity.java
@@ -20,6 +20,8 @@ public class MainActivity extends AppCompatActivity implements MainView {
     private static final int POSITION_LOADING = 1;
     private static final int POSITION_EMPTY = 2;
 
+    private static final String SIS_KEY_PRESENTER_ID = "presenter_id";
+
     private ViewAnimator animator;
     private CounterAdapter adapter;
 
@@ -32,7 +34,8 @@ public class MainActivity extends AppCompatActivity implements MainView {
         if (savedInstanceState == null) {
             presenter = new MainPresenter();
         } else {
-            presenter = PresenterManager.getInstance().restorePresenter(savedInstanceState);
+            long presenterId = savedInstanceState.getLong(SIS_KEY_PRESENTER_ID);
+            presenter = PresenterManager.getInstance().restorePresenter(presenterId);
         }
 
         setContentView(R.layout.activity_list);
@@ -81,7 +84,8 @@ public class MainActivity extends AppCompatActivity implements MainView {
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
 
-        PresenterManager.getInstance().savePresenter(presenter, outState);
+        long presenterId = PresenterManager.getInstance().savePresenter(presenter);
+        outState.putLong(SIS_KEY_PRESENTER_ID, presenterId);
     }
 
     @Override

--- a/app/src/main/java/com/remind101/archexample/PresenterManager.java
+++ b/app/src/main/java/com/remind101/archexample/PresenterManager.java
@@ -1,7 +1,5 @@
 package com.remind101.archexample;
 
-import android.os.Bundle;
-
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.remind101.archexample.presenters.BasePresenter;
@@ -10,7 +8,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class PresenterManager {
-    private static final String SIS_KEY_PRESENTER_ID = "presenter_id";
+
     private static PresenterManager instance;
 
     private final AtomicLong currentId;
@@ -33,16 +31,15 @@ public class PresenterManager {
         return instance;
     }
 
-    public <P extends BasePresenter<?, ?>> P restorePresenter(Bundle savedInstanceState) {
-        Long presenterId = savedInstanceState.getLong(SIS_KEY_PRESENTER_ID);
+    public <P extends BasePresenter<?, ?>> P restorePresenter(long presenterId) {
         P presenter = (P) presenters.getIfPresent(presenterId);
         presenters.invalidate(presenterId);
         return presenter;
     }
 
-    public void savePresenter(BasePresenter<?, ?> presenter, Bundle outState) {
+    public long savePresenter(BasePresenter<?, ?> presenter) {
         long presenterId = currentId.incrementAndGet();
         presenters.put(presenterId, presenter);
-        outState.putLong(SIS_KEY_PRESENTER_ID, presenterId);
+        return presenterId;
     }
 }


### PR DESCRIPTION
Delete dependence on android.os.Bundle from PresenterManager to make it clean.
Move mechanism of presenter id saving to lifecycle owner (MainActivity).